### PR TITLE
Update to match PEP3110

### DIFF
--- a/sphinx/btest-sphinx.py
+++ b/sphinx/btest-sphinx.py
@@ -86,7 +86,7 @@ class Test(object):
 
         try:
             subprocess.check_call("btest -S %s" % self.path, shell=True)
-        except (OSError, IOError, subprocess.CalledProcessError), e:
+        except (OSError, IOError, subprocess.CalledProcessError) as e:
             # Equivalent to Directive.error(); we don't have an
             # directive object here and can't pass it in because
             # it doesn't pickle.
@@ -111,7 +111,7 @@ class BTestTransform(Transform):
 
         try:
             rawtext = open("%s#%d" % (test.rst_output, part)).read()
-        except IOError, e:
+        except IOError as e:
             rawtext = ""
 
         settings = self.document.settings


### PR DESCRIPTION
This PR should enable to build the package with Python 3 while keeping the option to still use Python 2.6.

`btest` is part of the Fedora Package Collection and it will become a requirement to be able to build with Python 3.