### PR TITLE
Delete a test's temporary directory if skipped

### DIFF
--- a/btest
+++ b/btest
@@ -755,6 +755,8 @@ class Test(object):
 
             if not success:
                 self.mgr.testSkipped(self)
+                if not Options.tmps:
+                    self.rmTmp()
                 self.finish()
                 return
 


### PR DESCRIPTION
At the moment a test's temporary directory will stay in place when the test gets skipped. You can try this with the attached example:

    $ cd example
    $ btest -A -a local tests/
    [  0%] tests.failing [local] ... failed
    [ 33%] tests.skipped [local] ... not available, skipped
    [ 66%] tests.working [local] ... ok
    1 of 3 tests failed, 1 skipped
    $ find .tmp/
    .tmp/
    .tmp/tests.skipped
    .tmp/tests.skipped/.stderr
    .tmp/tests.skipped/skipped.sh
    .tmp/tests.skipped/.log
    .tmp/tests.skipped/.stdout
    .tmp/tests.failing
    .tmp/tests.failing/.stderr
    .tmp/tests.failing/failing.sh
    .tmp/tests.failing/.log
    .tmp/tests.failing/.stdout

The small tweak in this PR just adds the cleanup for skipped tests, unless the user really wants them.
[example.zip](https://github.com/bro/btest/files/2011256/example.zip)
