### PR TITLE
topic/jsiwek/port-command

### DIFF
--- a/README
+++ b/README
@@ -428,6 +428,11 @@ configuration file:
     measure the execution times of tests. By default, BTest searches
     for ``perf`` in ``PATH``.
 
+``PortRange``
+    Specifies a port range like "10000-11000" to use in conjuction with
+    ``@TEST-PORT`` commands.  Port assignments will be restricted to this
+    range.  The default range is "1024-65535".
+
 .. _environment variables:
 
 Environment Variables
@@ -759,6 +764,21 @@ supported:
    When using option ``-j`` to parallelize execution, all tests that
    specify the same serialization set are guaranteed to run
    sequentially. ``<set>`` is an arbitrary user-chosen string.
+
+.. _@TEST-PORT:
+
+``@TEST-PORT: <env>``
+   Assign an available TCP port number to an environment variable
+   that is accessible from the running test process.  ``<env>`` is an
+   arbitrary user-chosen string that will be set to the next available
+   TCP port number.  Availability is based on checking successful
+   binding of the port on IPv4 INADDR_ANY and also restricted to the
+   range specified by the ``PortRange`` option.  IPv6 is not supported.
+   Note that using the ``-j`` option to parallelize execution will
+   work such that unique/available port numbers are assigned between
+   concurrent tests, however there is still a potential race condition
+   for external processes to claim a port before the test actaully
+   runs and claims it for itself.
 
 ``@TEST-KNOWN-FAILURE``
    Marks a test as known to currently fail. This only changes BTest's

--- a/btest
+++ b/btest
@@ -282,6 +282,10 @@ class TestManager(multiprocessing.managers.SyncManager):
         self._failed_tests = self.list([])
         self._num_tests = len(self._tests)
         self._timing = self.loadTiming()
+        port_range = getOption("PortRange", "1024-65535")
+        port_range_lo = int(port_range.split("-")[0])
+        port_range_hi = int(port_range.split("-")[1])
+        self._ports = self.list([p for p in range(port_range_lo, port_range_hi)])
 
         num_threads = Options.threads
 
@@ -390,6 +394,40 @@ class TestManager(multiprocessing.managers.SyncManager):
 
         # No more tests for us.
         return None
+
+    def returnPorts(self, ports):
+        with self._lock:
+            for p in ports:
+                self._ports.append(p)
+
+    def getAvailablePorts(self, count):
+        with self._lock:
+            rval = []
+
+            for i in range(count):
+                while True:
+                    if len(self._ports) == 0:
+                        for s in rval:
+                            s.close()
+                            self._ports.append(s.getsockname()[1])
+                        return []
+
+                    next_port = self._ports[0]
+                    del self._ports[0]
+
+                    try:
+                        sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+                        sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+                        sock.bind(('', next_port))
+                    except:
+                        self._ports.append(next_port)
+                        continue
+                    else:
+                        break
+
+                rval.append(sock)
+
+            return rval
 
     def lock(self):
         return self._lock
@@ -517,6 +555,7 @@ class Test(object):
         self.part = -1
         self.number = 1
         self.serialize = []
+        self.ports = set()
         self.groups = set()
         self.cmdlines = []
         self.tmpdir = None
@@ -624,6 +663,9 @@ class Test(object):
         if "serialize" in cmds:
             self.serialize = cmds["serialize"]
 
+        if "port" in cmds:
+            self.ports |= set(cmd.strip() for cmd in cmds['port'])
+
         if "group" in cmds:
             self.groups |= set(cmd.strip() for cmd in cmds["group"])
 
@@ -659,7 +701,8 @@ class Test(object):
         clone.number = self.number + 1
         clone.basename = self.basename
         clone.name = "%s-%d" % (self.basename, clone.number)
-        clone.serialize = clone.serialize
+        clone.serialize = self.serialize
+        clone.ports = self.ports
         clone.groups = self.groups
         clone.cmdlines = self.cmdlines
         clone.known_failure = self.known_failure
@@ -679,6 +722,7 @@ class Test(object):
             error("cannot use @TEST-START-NEXT with tests split across parts (%s)" % self.basename)
 
         self.serialize += part.serialize
+        self.ports |= part.ports
         self.groups |= part.groups
         self.cmdlines += part.cmdlines
         self.ignore_alternatives += part.ignore_alternatives
@@ -691,7 +735,28 @@ class Test(object):
         self.known_failure |= part.known_failure
         self.measure_time |= part.measure_time
 
+    def getPorts(self, mgr, count):
+        if not count:
+            return []
+
+        while True:
+            rval = mgr.getAvailablePorts(count)
+
+            if rval:
+                return rval
+
+            warning("failed to retrieve {0} ports for test {1}, will try again".format(
+                count, self.name))
+
+            time.sleep(5)
+
     def run(self, mgr):
+        bound_sockets = self.getPorts(mgr, len(self.ports))
+        self.bound_ports = [s.getsockname()[1] for s in bound_sockets]
+
+        for bs in bound_sockets:
+            bs.close()
+
         self.start = time.time()
         self.mgr = mgr
         mgr.testStart(self)
@@ -842,6 +907,11 @@ class Test(object):
         self.finish()
 
     def finish(self):
+        if self.bound_ports:
+            self.mgr.returnPorts([p for p in self.bound_ports])
+
+        self.bound_ports = []
+
         try:
             # Try removing the baseline directory. If it works, it's empty, i.e., no baseline was created.
             os.rmdir(self.baseline)
@@ -955,6 +1025,9 @@ class Test(object):
 
         for (key, val) in addl.items():
             env[key.upper()] = val
+
+        for idx, key in enumerate(sorted(self.ports)):
+            env[key] = str(self.bound_ports[idx]) + "/tcp"
 
         return env
 
@@ -2098,6 +2171,7 @@ RE_EXEC                = ("exec",            re.compile(CommandPrefix + "EXEC(-F
 RE_REQUIRES            = ("requires",        re.compile(CommandPrefix + "REQUIRES: *(.*)"), True, True, 1, -1)
 RE_GROUP               = ("group",           re.compile(CommandPrefix + "GROUP: *(.*)"), True, True, 1, -1)
 RE_SERIALIZE           = ("serialize",       re.compile(CommandPrefix + "SERIALIZE: *(.*)"), False, True, 1, -1)
+RE_PORT                = ("port",            re.compile(CommandPrefix + "PORT: *(.*)"), True, True, 1, -1)
 RE_INCLUDE_ALTERNATIVE = ("alternative",     re.compile(CommandPrefix + "ALTERNATIVE: *(.*)"), True, True, 1, -1)
 RE_IGNORE_ALTERNATIVE  = ("not-alternative", re.compile(CommandPrefix + "NOT-ALTERNATIVE: *(.*)"), True, True, 1, -1)
 RE_COPY_FILE           = ("copy-file",       re.compile(CommandPrefix + "COPY-FILE: *(.*)"), True, True, 1, -1)
@@ -2105,7 +2179,7 @@ RE_KNOWN_FAILURE       = ("known-failure",   re.compile(CommandPrefix + "KNOWN-F
 RE_MEASURE_TIME        = ("measure-time",    re.compile(CommandPrefix + "MEASURE-TIME"), False, True, -1, -1)
 RE_DOC                 = ("doc",             re.compile(CommandPrefix + "DOC: *(.*)"), True, True, 1, -1)
 
-Commands = (RE_EXEC, RE_REQUIRES, RE_GROUP, RE_SERIALIZE, RE_INCLUDE_ALTERNATIVE, RE_IGNORE_ALTERNATIVE, RE_COPY_FILE, RE_KNOWN_FAILURE, RE_MEASURE_TIME, RE_DOC)
+Commands = (RE_EXEC, RE_REQUIRES, RE_GROUP, RE_SERIALIZE, RE_PORT, RE_INCLUDE_ALTERNATIVE, RE_IGNORE_ALTERNATIVE, RE_COPY_FILE, RE_KNOWN_FAILURE, RE_MEASURE_TIME, RE_DOC)
 
 StateFile = os.path.abspath(getOption("StateFile", os.path.join(defaults["testbase"], ".btest.failed.dat")))
 TmpDir = os.path.abspath(getOption("TmpDir", os.path.join(defaults["testbase"], ".tmp")))

--- a/btest
+++ b/btest
@@ -448,14 +448,19 @@ class TestManager(multiprocessing.managers.SyncManager):
 
                     del self._ports[0]
 
-                    try:
-                        sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
-                        # Setting REUSEADDR would allow ports to be recycled
-                        # more quickly, but on macOS, seems to also have the
-                        # effect of allowing multiple sockets to bind to the
-                        # same port, event if REUSEPORT is off.
+                    sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+
+                    # Setting REUSEADDR would allow ports to be recycled
+                    # more quickly, but on macOS, seems to also have the
+                    # effect of allowing multiple sockets to bind to the
+                    # same port, even if REUSEPORT is off, so just try to
+                    # ensure both are off.
+                    if hasattr(socket, 'SO_REUSEADDR'):
                         sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 0)
+                    if hasattr(socket, 'SO_REUSEPORT'):
                         sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEPORT, 0)
+
+                    try:
                         sock.bind(('', next_port))
                     except:
                         self._ports.append(next_port)

--- a/btest
+++ b/btest
@@ -282,10 +282,26 @@ class TestManager(multiprocessing.managers.SyncManager):
         self._failed_tests = self.list([])
         self._num_tests = len(self._tests)
         self._timing = self.loadTiming()
+
         port_range = getOption("PortRange", "1024-65535")
         port_range_lo = int(port_range.split("-")[0])
         port_range_hi = int(port_range.split("-")[1])
-        self._ports = self.list([p for p in range(port_range_lo, port_range_hi)])
+
+        if port_range_lo > port_range_hi:
+            error("invalid PortRange value: {0}".format(port_range))
+
+        max_test_ports = 0
+        test_with_most_ports = None
+
+        for t in self._tests:
+            if len(t.ports) > max_test_ports:
+                max_test_ports = len(t.ports)
+                test_with_most_ports = t
+
+        if max_test_ports > port_range_hi - port_range_lo + 1:
+            error("PortRange {0} cannot satisfy requirement of {1} ports in test {2}".format(port_range, max_test_ports, test_with_most_ports.name))
+
+        self._ports = self.list([p for p in range(port_range_lo, port_range_hi + 1)])
 
         num_threads = Options.threads
 
@@ -402,6 +418,11 @@ class TestManager(multiprocessing.managers.SyncManager):
 
     def getAvailablePorts(self, count):
         with self._lock:
+
+            if count > len(self._ports):
+                return []
+
+            first_port = -1
             rval = []
 
             for i in range(count):
@@ -413,11 +434,28 @@ class TestManager(multiprocessing.managers.SyncManager):
                         return []
 
                     next_port = self._ports[0]
+
+                    if next_port == first_port:
+                        # Looped over port pool once, bail out.
+                        for s in rval:
+                            s.close()
+                            self._ports.append(s.getsockname()[1])
+
+                        return []
+
+                    if first_port == -1:
+                        first_port = next_port
+
                     del self._ports[0]
 
                     try:
                         sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
-                        sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+                        # Setting REUSEADDR would allow ports to be recycled
+                        # more quickly, but on macOS, seems to also have the
+                        # effect of allowing multiple sockets to bind to the
+                        # same port, event if REUSEPORT is off.
+                        sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 0)
+                        sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEPORT, 0)
                         sock.bind(('', next_port))
                     except:
                         self._ports.append(next_port)
@@ -739,16 +777,24 @@ class Test(object):
         if not count:
             return []
 
+        attempts = 5
+
         while True:
             rval = mgr.getAvailablePorts(count)
 
             if rval:
                 return rval
 
-            warning("failed to retrieve {0} ports for test {1}, will try again".format(
-                count, self.name))
+            attempts -= 1
 
-            time.sleep(5)
+            if attempts == 0:
+                error("failed to obtain {0} ports for test {1}".format(
+                    count, self.name))
+
+            warning("failed to obtain {0} ports for test {1}, will try {2} more times".format(
+                count, self.name, attempts))
+
+            time.sleep(15)
 
     def run(self, mgr):
         bound_sockets = self.getPorts(mgr, len(self.ports))

--- a/testing/tests/ports.test
+++ b/testing/tests/ports.test
@@ -1,0 +1,10 @@
+
+# %TEST-EXEC: btest -t %INPUT
+# %TEST-EXEC: test 3 -eq `wc -l .tmp/ports/output | cut -d" " -f1`
+
+@TEST-PORT: MYPORT1
+@TEST-PORT: MYPORT2
+@TEST-PORT: MYPORT3
+@TEST-EXEC: echo $MYPORT1 >>output
+@TEST-EXEC: echo $MYPORT2 >>output
+@TEST-EXEC: echo $MYPORT3 >>output

--- a/testing/tests/ports.test
+++ b/testing/tests/ports.test
@@ -1,6 +1,6 @@
 
 # %TEST-EXEC: btest -t %INPUT
-# %TEST-EXEC: test 3 -eq `wc -l .tmp/ports/output | cut -d" " -f1`
+# %TEST-EXEC: test 3 -eq `wc -l .tmp/ports/output | awk '{print $1}'`
 
 @TEST-PORT: MYPORT1
 @TEST-PORT: MYPORT2


### PR DESCRIPTION
Adds `TEST-PORT` command and `PortRange` option to facilitate parallelizing tests that require binding/listening on a TCP port.